### PR TITLE
Update payfast.php

### DIFF
--- a/modules/gateways/payfast.php
+++ b/modules/gateways/payfast.php
@@ -154,7 +154,7 @@ function Payfast_nolocalcc(): void
  * @return array|string
  * @see https://developers.whmcs.com/payment-gateways/remote-input-gateway/
  */
-function Payfast_remoteinput(): array|string
+function Payfast_remoteinput(): array
 {
     return "<div class=\"alert alert-info\">A new card can only be added when paying an invoice. </p>";
 }
@@ -177,7 +177,7 @@ function Payfast_remoteinput(): array|string
  * @see https://developers.whmcs.com/payment-gateways/remote-input-gateway/
  *
  */
-function Payfast_remoteupdate($params): array|string
+function Payfast_remoteupdate($params): array
 {
     if (!$params["gatewayid"]) {
         return "<p align=\"center\">You must pay your first invoice via credit


### PR DESCRIPTION
Stack trace error when activating the gateway in WHMCS.

The "| string" in line 157 and 180 is not valid in this case since the function has been already declared as an array.